### PR TITLE
Stop using rems by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # OSX Files
 .DS_Store
+
+# Test files
+test/test.css

--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -50,8 +50,8 @@ textarea,
 [type="tel"],
 [type="color"] {
     width: 100%;
-    height: rem(40px);
-    padding: rem(10px) rem(15px);
+    height: 40px;
+    padding: 10px 15px;
     margin-bottom: $base-margin;
     border: $base-border;
 
@@ -79,10 +79,10 @@ textarea {
 }
 
 select {
-    padding: rem(8px) rem(15px);
+    padding: 8px 15px;
     border-color: darken($form-border-color, 0.25);
     
-    text-indent: rem(5px);
+    text-indent: 5px;
     
     // Turn Select Appearance back on
     // If you want to style this select box, delete this line
@@ -96,8 +96,8 @@ select {
 
     display: inline-block;
     margin-right: $base-margin;
-    width: rem(24px);
-    height: rem(24px);
+    width: 24px;
+    height: 24px;
     border: 1px solid darken($form-border-color, 0.25);
     
     background: $grey10 $light-gradient;
@@ -126,7 +126,7 @@ select {
 }
 
 [type="radio"] {
-    border-radius: rem(24px);
+    border-radius: 24px;
     
     &:after {
         top: 20%;
@@ -135,7 +135,7 @@ select {
         bottom: 20%;
 
         background: $grey50;
-        border-radius: rem(24px);
+        border-radius: 24px;
     }
 }
 
@@ -146,7 +146,7 @@ select {
             
             top: 0;
             
-            font-size: rem(32px);
+            font-size: 32px;
             font-family: $form-font-family;
             color: $grey50;
             line-height: $form-font-size;
@@ -160,7 +160,7 @@ button,
 [type="submit"] {
     display: block;
     width: 100%;
-    padding: rem(10px) rem(15px);
+    padding: 10px 15px;
     
     background: $light-gradient;
     border: 1px solid darken($form-border-color, 0.25);

--- a/dist/vellum/_typography.scss
+++ b/dist/vellum/_typography.scss
@@ -1,12 +1,6 @@
 // TYPOGRAPHY
 // ==========
 
-// HTML
-// ----
-html {
-    font-size: $rem-base;
-}
-
 // BODY
 // ----
 
@@ -34,27 +28,27 @@ h6 {
 
 %h1,
 h1 {
-    font-size: rem(28px);
+    font-size: 28px;
 }
 
 %h2,
 h2 {
-    font-size: rem(24px);
+    font-size: 24px;
 }
 
 %h3,
 h3 {
-    font-size: rem(20px);
+    font-size: 20px;
 }
 
 %h4,
 h4 {
-    font-size: rem(18px);
+    font-size: 18px;
 }
 
 %h5,
 h5 {
-    font-size: rem(16px);
+    font-size: 16px;
 }
 
 %h6,

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -12,15 +12,14 @@ $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;
 
 // Sizes
-$rem-base: 100%;
-$base-font-size: rem(14px);
+$base-font-size: 14px;
 $base-line-height: $base-font-size * 1.5;
 
 
 // SIZING
 // ------
 
-$base-border-radius: rem(4px);
+$base-border-radius: 4px;
 $base-margin: $base-line-height * .5;
 
 


### PR DESCRIPTION
# Stop using rems by default

Status: **Opened for visibility**
Reviewers: @jeffkamo @ry5n 
## Changes
1. Removed all references to the `rem()` function
2. Back to sweet sweet pixels
## Notes
- Some usage of this may result in half-pixels appearing in our `$margin` variables or line heights. I don't think this is a real problem but I'm open to opinions.
- Fixes #9 
