### PR TITLE
Remove outline: none declaration from forms.scss

### DIFF
--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -56,7 +56,6 @@ textarea,
     border: $base-border;
 
     background-color: #fff;
-    outline: none;
     border-radius: $base-border-radius;
 
     line-height: $base-line-height;
@@ -70,7 +69,6 @@ textarea,
     
     &:focus {
         border-color: $form-border-color-focus;
-        outline: none;
     }
 }
 


### PR DESCRIPTION
# Remove outline: none declaration from forms.scss

Status: **Merge this bitch**
Reviewers: @ry5n @jeffkamo 
## Changes
1. Pretty obvious.
