### PR TITLE
Use default margins on input fields

### DIFF
--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -52,7 +52,6 @@ textarea,
     width: 100%;
     height: 40px;
     padding: 10px 15px;
-    margin-bottom: $base-margin;
     border: $base-border;
 
     background-color: #fff;


### PR DESCRIPTION
Fix #18 — Use default margins on input fields

Status: **Opened for visibility**
Reviewers: @jeffkamo @ry5n 
## Changes
- Removed bottom margin being set on input fields
