### PR TITLE
Add $v-space and $h-space variables instead of $margin

### DIFF
--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -19,8 +19,9 @@ $form-font-family: $font-family;
 // ### General Form Elements
 
 fieldset {
+    min-width: 0;
     padding: 0;
-    margin: 0 0 $margin 0;
+    margin: 0 0 $v-space 0;
     border: 0;
 }
 
@@ -35,7 +36,7 @@ select {
 
 label {
     font-weight: bold;
-    margin-bottom: $margin / 2;
+    margin-bottom: $v-space / 2;
     
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     
@@ -106,7 +107,7 @@ select {
     top: -2px; // Aligns them with any inline content that follows
 
     display: inline-block;
-    margin-right: $margin;
+    margin-right: $h-space / 2;
     width: 24px;
     height: 24px;
     border: 1px solid darken($form-border-color, 0.25);

--- a/dist/vellum/_lists.scss
+++ b/dist/vellum/_lists.scss
@@ -14,25 +14,25 @@ ol {
 // Use this extension to turn default styling for unordered lists back on
 %bullet-list {
     list-style-type: disc;
-    margin-bottom: $margin;
-    padding-left: $line-height;
+    margin-bottom: $v-space;
+    padding-left: $h-space;
 }
 
 // Use this extension to turn default styling for ordered lists back on
 %decimal-list {
     list-style-type: decimal;
-    margin-bottom: $margin;
-    padding-left: $line-height;
+    margin-bottom: $v-space;
+    padding-left: $h-space;
 }
 
 dl {
     line-height: $line-height;
-    margin-bottom: $margin;
+    margin-bottom: $v-space;
 }
 
 dt {
     font-weight: bold;
-    margin-top: $margin;
+    margin-top: $v-space;
 }
 
 dd {

--- a/dist/vellum/_tables.scss
+++ b/dist/vellum/_tables.scss
@@ -3,20 +3,20 @@
 
 table {
     border-collapse: collapse;
-    margin: $margin 0;
+    margin: $v-space 0;
     width: 100%;
 }
 
 th {
     border-bottom: 1px solid darken($border-color, 15%);
     font-weight: bold;
-    padding: $margin 0;
+    padding: $v-space 0;
     text-align: left;
 }
 
 td {
   border-bottom: 1px solid $border-color;
-  padding: $margin 0;
+  padding: $v-space 0;
 }
 
 tr,

--- a/dist/vellum/_typography.scss
+++ b/dist/vellum/_typography.scss
@@ -61,7 +61,7 @@ h6 {
 }
 
 p {
-    margin: 0 0 $margin;
+    margin: 0 0 $v-space;
 }
 
 a {
@@ -75,7 +75,7 @@ a {
 }
 
 hr {
-    margin: $line-height 0;
+    margin: $v-space*2 0;
     border: 1px solid $border-color;
     border-width: 0 0 1px;
 }
@@ -87,11 +87,11 @@ img {
 
 address {
     display: block;
-    margin: 0 0 $margin;
+    margin: 0 0 $v-space;
 }
 
 hgroup {
-    margin-bottom: $margin;
+    margin-bottom: $v-space;
 }
 
 del {
@@ -99,8 +99,8 @@ del {
 }
 
 blockquote {
-    margin: $line-height 0;
-    padding-left: $margin;
+    margin: $v-space*2 0;
+    padding-left: $h-space;
     border-left: 2px solid $border-color;
     
     color: lighten($font-color, 15);

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -135,7 +135,8 @@ $border-radius: 4px;
 // LAYOUT
 // ------
 
-$margin: $line-height * 0.5;
+$h-space: $line-height;
+$v-space: $line-height * 0.5;
 
 
 // Z-INDEX

--- a/test/test.scss
+++ b/test/test.scss
@@ -5,11 +5,11 @@
 // Test CSS
 
 body {
-    padding: $margin;
+    padding: $v-space $h-space;
 }
 
 h1[id] {
-    margin-bottom: $margin;
+    margin-bottom: $v-space;
 }
 
 ul.default {


### PR DESCRIPTION
Use $v-space and $h-space variables instead of $margin (Fixes #10)

Status: **Ready for speedy merging**
Reviewers: @jeffkamo @ry5n 
## Changes
1. Removed `$margin` variable
2. Added `$v-space` and `$h-space` references
3. Changed out all references to `$margin` with references to `$v-space` or `$h-space` depending on the context.
4. Fixed an issue with `fieldset` needing `min-width` to be reset to `0`.
## Notes
- Funny issue, the `min-space` one. It seems like Safari defaults to `-webkit-min-content` as a value for `fieldset`. This causes the `fieldset` to be quite a bit wider than you may want in some situations. Resetting `min-width` to `0` fixes this.
- Fixes #10.
