### PR TITLE
Fix input[type="search"] Specifity

### DIFF
--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -20,7 +20,7 @@ $form-font-family: $font-family;
 //
 // Notes:
 //
-// 1. These properties must be set with a slightly higher specitiy for search inputs
+// 1. These properties must be set with a slightly higher specificity for search inputs
 //    because Normalize's defaults are a bit too specific
 
 fieldset {


### PR DESCRIPTION
Fix search input default styles. Normalize's defaults are a bit too high in specificity, which means we have to slightly increase our specificity too.

Status: **Opened for visibility**
Reviewers: @kpeatt, @ry5n 
JIRA: N/A
## Changes
- Declared `box-sizing` and `-webkit-appearance` on a slightly higher specificity selector for search inputs
