### PR TITLE
Add 'orchestra' to z-index stage metaphor

### DIFF
--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -113,10 +113,11 @@ $v-space: $line-height * 0.5;
 // Organizes z-index usage by providing a set of named layers. Values can be
 // incremented/decremented slightly as necessary. eg. $stage-layer + 1;
 //
-// 1. “backdrop” should be your first resort for bringing an item up. Likely
-//    an icon.
-// 2. "stage" should be used when backdrop isn't enough. Likely a menu overlay.
-// 3. "orchestra" should be used to explicitly place content in front.
+// 1. “backdrop” should be used for purposefully placing an item behind a staged item. Likely
+//    a background for an element.
+// 2. "stage" should be your first choice for moving an item in front of others. Likely an icon or
+//    an interface element.
+// 3. "orchestra" should be used to explicitly place content in front of the stage.
 //    Likely a modal shield.
 // 4. "frontrow" is your last resort for moving content forward. Likely a
 //    modal dialog.


### PR DESCRIPTION
# Update Stage Metaphor with 'Orchestra'

Status: **Opened for visibility**
Reviewers: @jeffkamo @ry5n 
## Changes
- Change what was previously `$frontrow-layer` to be `$orchestra-layer`
- Change what was previously `$overlay-layer` to be `$frontrow-layer`
## Notes
- Suggestion from @noahadams to help solidify the stage metaphor.
