### PR TITLE
Add rounding function to v-space variable

### DIFF
--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -104,7 +104,7 @@ $border-radius: 4px;
 // ------
 
 $h-space: $line-height;
-$v-space: $line-height * 0.5;
+$v-space: round($line-height * 0.5);
 
 
 // Z-INDEX


### PR DESCRIPTION
Because sometimes when the browser does the rounding it can sometimes round up or down and create unequal vertical spacing.

Status: **Ready for review**

Reviewers: @jeffkamo @ry5n @kpeatt
