### PR TITLE
Refactor code to match current conventions

### DIFF
--- a/dist/vellum/_lists.scss
+++ b/dist/vellum/_lists.scss
@@ -21,7 +21,7 @@ ol {
 // If you want to have your unordered lists have default styles, uncomment the
 // following code:
 //
-// ul {
+// %ul {
 //     margin-bottom: $v-space;
 //     padding-left: $h-space;
 //     list-style-type: disc;
@@ -30,7 +30,7 @@ ol {
 // If you want to have your ordered lists have default styles, uncomment the
 // following code:
 //
-// ol {
+// %ol {
 //     margin-bottom: $v-space;
 //     padding-left: $h-space;
 //     list-style-type: decimal;

--- a/dist/vellum/_typography.scss
+++ b/dist/vellum/_typography.scss
@@ -17,27 +17,33 @@ h6 {
     line-height: 1.25;
 }
 
-h1 {
+h1,
+%h1 {
     font-size: 28px;
 }
 
-h2 {
+h2,
+%h2 {
     font-size: 24px;
 }
 
-h3 {
+h3,
+%h3 {
     font-size: 20px;
 }
 
-h4 {
+h4,
+%h4 {
     font-size: 18px;
 }
 
-h5 {
+h5,
+%h5 {
     font-size: 16px;
 }
 
-h6 {
+h6,
+%h6 {
     font-size: $font-size;
 }
 


### PR DESCRIPTION
**Note**: This is a re-PR of #54, except with a few of the original changes undone (see below)

This is an update to Vellum such that the CSS is written in a way that follows our current standards and conventions.

Status: **Ready for Review**
Reviewers: @kpeatt @ry5n 
JIRA: **CSOPS-846**
## Changes
- Set headings to standard capitilization
- Max of three `=` or `-` when underlining headings
- Fixed property orders to match our linting rules
- Repositioned line comments
- Corrected line comments to be written using the numbered notation
- Cleaned up unnecessary third level headings
- Added a few extra headings for clarity
- Tried to make the variable's introductory bullet list a bit more readable
- Disable `*::before/after` by default due to Android 4.1.x performance issues, fixed #53
- Add `[hidden]` attribute styles (moved over from Stencil)... thoughts over the location of these styles can be discussed in #55
## Reverted Changes
- Un-removed any placeholder classes (placeholder classes are still present in this version), let's discuss this in detail over at #56
