### PR TITLE
Text-indent removed from forms>select

### DIFF
--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -100,8 +100,6 @@ select {
     padding: 8px 15px;
     border-color: darken($forms__border-color, 0.25);
 
-    text-indent: 5px;
-
     // Turn Select Appearance back on
     // If you want to style this select box, delete this line
     -webkit-appearance: menulist-button;


### PR DESCRIPTION
Status: **Ready for Review**
Owner: Anastasia Tikk
Reviewers: @kpeatt @ry5n @cole-sanderson @avelinet @jeffkamo @mlworks 

## Changes
Select property `text-indent: 5px` removed.

I have checked randomly several projects. Select has the next parameters there:
* In **BRT**, **CR**, **MTL**, **NDSTR** projects `text-indent: 0`
* **WHS** `text-indent: 5px` but select is hidden there and `span` is displayed instead so it doesn't count as `5px` intent
* **CRNV** `text-indent: 2px`

Probably we still need to make some tests but seems like this property is more project-specific then global. 

The alignment is also displayed buggy in **stencil-select** where select has `text-indent: 5px` by default and displayed fine when `text-indent: 0;`

![screenshot 2015-03-12 16 41 57](https://cloud.githubusercontent.com/assets/4110509/6630455/6a5efef8-c8d6-11e4-9301-6496dcb1d32c.png)


## Todos:
- [x] Designer +1
- [x] Designer +1

### Feedback:
_none so far_