### PR TITLE
Ignore Sass sourcemaps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ node_modules
 
 # Generated CSS
 *.css
+*.css.map
 
 .idea/


### PR DESCRIPTION
Ignore Sass sourcemaps.

Status: **Ready to merge**

Reviewers: @jeffkamo @avelinet @nastiatikk 

## Changes
- Ignore sourcemaps in version control (compiled CSS is already ignored)