### PR TITLE
Prepare Vellum to work with Stencil

### DIFF
--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -18,8 +18,8 @@ textarea,
 select {
     display: block;
 
-    font-family: $forms-font-family;
-    font-size: $forms-font-size;
+    font-family: $font-family;
+    font-size: $font-size;
 }
 
 label {
@@ -47,9 +47,9 @@ textarea,
     padding: 10px 15px;
     border: $border;
 
-    border-radius: $forms-border-radius;
+    border-radius: $border-radius;
 
-    background-color: $forms-input-color;
+    background-color: $input-background-color;
 
     line-height: $line-height;
 
@@ -57,15 +57,15 @@ textarea,
     -webkit-appearance: none;
 
     &::-webkit-input-placeholder {
-        color: $forms-placeholder-color;
+        color: $neutral-50;
     }
 
     &:active {
-        border-color: $forms-active-border-color;
+        border-color: darken($border-color, 10%);
     }
 
     &:focus {
-        border-color: $forms-focus-border-color;
+        border-color: $focus-color;
     }
 }
 
@@ -95,7 +95,7 @@ input[type="search"] {
 
 select {
     padding: 8px 15px;
-    border-color: darken($forms-border-color, 0.25);
+    border-color: darken($border-color, 0.25);
 
     -webkit-appearance: menulist-button; // 1
 }
@@ -115,7 +115,7 @@ select {
     width: 24px;
     height: 24px;
     margin-right: $unit;
-    border: 1px solid darken($forms-border-color, 0.25);
+    border: 1px solid darken($border-color, 0.25);
 
     background: $neutral-30 $neutral-gradient;
 
@@ -130,7 +130,7 @@ select {
     }
 
     &:checked {
-        background: $forms-checked-background;
+        background: $neutral-30;
         box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 
         &::after {
@@ -165,9 +165,9 @@ select {
             top: 0;
 
             color: $neutral-70;
-            font-family: $forms-font-family;
+            font-family: $font-family;
             font-size: 32px;
-            line-height: $forms-font-size;
+            line-height: $font-size;
         }
     }
 }
@@ -180,7 +180,7 @@ button,
 [type="submit"] {
     display: block;
     padding: 10px 15px;
-    border: 1px solid darken($forms-border-color, 0.25);
+    border: 1px solid darken($border-color, 0.25);
 
     background: $neutral-30 $neutral-gradient;
 
@@ -203,29 +203,29 @@ button,
 [disabled] {
     opacity: 1;
 
-    background: $forms-disabled-background;
+    background: $input-disabled-background;
 
-    color: $forms-disabled-color;
+    color: $input-disabled-color;
 
-    -webkit-text-fill-color: $forms-disabled-color; // 1
+    -webkit-text-fill-color: $input-disabled-color; // 1
 
     // 2
     &:active,
     &:checked {
-        border-color: $forms-disabled-color;
+        border-color: $input-disabled-color;
 
-        background: $forms-disabled-background;
+        background: $input-disabled-background;
     }
 
     // 3
     &:active,
     &:checked {
         &::after {
-            color: $forms-disabled-color;
+            color: $input-disabled-color;
         }
     }
 
     &[type="radio"]:after {
-        background-color: $forms-disabled-color;
+        background-color: $input-disabled-color;
     }
 }

--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -43,7 +43,7 @@ textarea,
 [type="number"],
 [type="email"] {
     width: 100%;
-    height: 40px;
+    min-height: $tap-size;
     padding: $input-padding;
     border: $border;
 
@@ -69,10 +69,6 @@ textarea,
     }
 }
 
-textarea {
-    height: auto;
-}
-
 
 // Search input
 // ---
@@ -90,10 +86,11 @@ input[type="search"] {
 // Select
 // ---
 //
-// 1. Turn Select Appearance back on.
-//    If you want to style this select box, delete this line
+// 1. Restore browser default styling. If you’re taking full control of select
+//    styling, remove both these lines.
 
 select {
+    height: $tap-size; // 1
     -webkit-appearance: menulist-button; // 1
 }
 
@@ -176,6 +173,7 @@ select {
 button,
 [type="submit"] {
     display: block;
+    min-height: $tap-size;
     padding: $input-padding;
     border: 1px solid darken($border-color, 0.25);
 

--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -204,29 +204,29 @@ button,
 [disabled] {
     opacity: 1;
 
-    background: $input-disabled-background;
+    background: $disabled-input-background-color;
 
-    color: $input-disabled-color;
+    color: $disabled-input-color;
 
-    -webkit-text-fill-color: $input-disabled-color; // 1
+    -webkit-text-fill-color: $disabled-input-color; // 1
 
     // 2
     &:active,
     &:checked {
-        border-color: $input-disabled-color;
+        border-color: $disabled-input-color;
 
-        background: $input-disabled-background;
+        background: $disabled-input-background-color;
     }
 
     // 3
     &:active,
     &:checked {
         &::after {
-            color: $input-disabled-color;
+            color: $disabled-input-color;
         }
     }
 
     &[type="radio"]:after {
-        background-color: $input-disabled-color;
+        background-color: $disabled-input-color;
     }
 }

--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -94,8 +94,6 @@ input[type="search"] {
 //    If you want to style this select box, delete this line
 
 select {
-    border-color: darken($border-color, 0.25);
-
     -webkit-appearance: menulist-button; // 1
 }
 

--- a/dist/vellum/_forms.scss
+++ b/dist/vellum/_forms.scss
@@ -44,7 +44,7 @@ textarea,
 [type="email"] {
     width: 100%;
     height: 40px;
-    padding: 10px 15px;
+    padding: $input-padding;
     border: $border;
 
     border-radius: $border-radius;
@@ -94,7 +94,6 @@ input[type="search"] {
 //    If you want to style this select box, delete this line
 
 select {
-    padding: 8px 15px;
     border-color: darken($border-color, 0.25);
 
     -webkit-appearance: menulist-button; // 1
@@ -179,10 +178,12 @@ select {
 button,
 [type="submit"] {
     display: block;
-    padding: 10px 15px;
+    padding: $input-padding;
     border: 1px solid darken($border-color, 0.25);
 
     background: $neutral-30 $neutral-gradient;
+
+    line-height: $line-height;
 
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-appearance: none;

--- a/dist/vellum/_global.scss
+++ b/dist/vellum/_global.scss
@@ -21,7 +21,7 @@ html {
     color: $font-color;
     font-family: $font-family;
     font-size: $font-size;
-    line-height: $leading-ratio; // 1
+    line-height: $line-height/$font-size; // 1
 }
 
 // Hidden

--- a/dist/vellum/_global.scss
+++ b/dist/vellum/_global.scss
@@ -16,8 +16,6 @@
 }
 
 html {
-    background: $background-color;
-
     color: $font-color;
     font-family: $font-family;
     font-size: $font-size;

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -94,10 +94,13 @@ $vertical-input-padding: $unit;
 // Layer (z-index)
 // ---
 
-$layer-00: 1;    // background
-$layer-10: 10;   // icon or other ui element
-$layer-20: 100;  // modal shade or similar
-$layer-30: 1000; // modal dialog or similar
+// Organizes z-index usage by name. Values can be incremented/decremented
+// slightly as necessary. eg. $stage-layer + 1;
+
+$backdrop-layer:  1;    // background
+$stage-layer:     10;   // icon or other ui element
+$orchestra-layer: 100;  // modal shade or similar
+$frontrow-layer:  1000; // modal dialog or similar
 
 
 // Shorthand

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -64,10 +64,6 @@ $font-color: $neutral-70;
 $link-color: $accent-color;
 $active-link-color: $dark-accent-color;
 
-// Background and border colors
-$background-color: white;
-$border-color: $neutral-40;
-
 
 // Gradients
 // ---
@@ -83,13 +79,14 @@ $accent-gradient: linear-gradient($light-accent-color, $accent-color);
 // Appearance
 // ---
 
-$border-radius: 4px;
-$focus-color: $accent-color;
 $input-horizontal-padding: $unit;
 $input-vertical-padding: $unit;
+$border-color: $neutral-40;
+$border-radius: 4px;
 $input-background-color: #fff;
 $input-disabled-color: $neutral-40;
 $input-disabled-background: $neutral-30;
+$focus-color: $accent-color;
 
 
 // Layer (z-index)

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -1,108 +1,82 @@
 // Variables
 // ===
 //
-// Variables are formatted using the following rules:
-//
-// * Names must be lowercase and dash-separated (kebab-case).
-//
-// * Names should represent properties or applications as closely as possible
-//
-// * Modifiers, qualifiers, or applications should be prepended to the variable
-//   name. e.g. $form-family (bad) vs. $form-font-family (better)
-//
-// * Variables without a qualifier are considered “base” variables,
-//   i.e. the default value for that type, e.g. $font-size, $brand-color,
-//   $neutral-50.
-//
-// * Variables with qualifiers at the beginning are considered “variations” on a
-//   base variable, e.g. $small-font-size, $light-brand-color.
-//
-// * Neutral variables use a scale defined in multiples of 10
-//   from $neutral-30 (lightest) to $neutral-70 (darkest). Their value can be changed
-//   according to the project needs but variable names should remain the same.
-//   This provides room to adjust values without changing variable names,
-//   but allows users to use more neutral variables. Additional variables can be
-//   inserted between, below or above these values depending on the colour intensity
-//   and be named $neutral-55, $neutral-25, etc.
+// - Names should be lowercase and dash-separated;
+// - Related variables should add qualifiers at the beginning: use
+//   `$small-font-size`, not `$font-size-small`;
+// - Numeric scales should use increments of 10; these numbers are arbitrary and
+//   should not map to actual values. If really necessary, additional values can
+//   be added in between, e.g. $neutral-15 between 10 and 20.
+
+
+// Layout
+// ---
+
+// Basic unit for spacing and alignment of elements. Suggested value: 6 to 12px.
+// Apply in whole or half multiples.
+$unit: 10px !default;
+
+// Standard tap-target size
+$tap-size: 45px !default;
 
 
 // Typography
 // ---
 
-$sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
-$serif: Georgia, Times, "Times New Roman", serif;
-
-$font-family: $sans-serif;
+$font-family: 'Helvetica Neue', 'Roboto', sans-serif;
 $header-font-family: $font-family;
-
 $font-size: 14px;
-$leading-ratio: 1.5;
-$line-height: $font-size * $leading-ratio;
+$line-height: 20px;
 
 
-// Colors
+// Color palette
 // ---
 
 // Neutrals
-$neutral-30: #E8E8E8;
-$neutral-40: #BBB;
+$neutral-30: #e8e8e8;
+$neutral-40: #bbb;
 $neutral-50: #888;
 $neutral-60: #555;
 $neutral-70: #333;
 
-// Brand Colors
+// Brand colors
 $brand-color: #3498db; // blue
 $light-brand-color: lighten($brand-color, 15%);
 $dark-brand-color: darken($brand-color, 15%);
 
-// Accent Colors
+// Accent colors
 $accent-color: #16a085; // turquoise
 $light-accent-color: lighten($accent-color, 15%);
 $dark-accent-color: darken($accent-color, 15%);
 
-// Success Colors
+// Success colors
 $success-color: #27ae60; // green
 $light-success-color: lighten($success-color, 15%);
 $dark-success-color: darken($success-color, 15%);
 
-// Error Colors
+// Error colors
 $error-color: #c0392b; // red
 $light-error-color: lighten($error-color, 15%);
 $dark-error-color: darken($error-color, 15%);
 
-// Disabled Color
-$disabled-color: $neutral-40;
-
-// Font Colors
+// Text colors
 $font-color: $neutral-70;
-
-// Text Link Colors
 $link-color: $accent-color;
 $active-link-color: $dark-accent-color;
 
-// Background Colors
+// Background and border colors
 $background-color: white;
-
-// Borders
 $border-color: $neutral-40;
 
 
-// Gradient Colors
+// Gradients
 // ---
 //
-// Variables containing all of the gradients used in the site
-// e.g. background-image: $light-neutral-gradient;
-//
-// To reverse a gradient, you can use the Spline function `reverse-gradient()`
-// e.g. background-image: reverse-gradient($neutral-gradient);
+// Note: Spline provides a handy function for reversing a gradient,
+// e.g. `reverse-gradient($neutral-gradient)`;
 
-// Neutral Gradient
 $neutral-gradient: linear-gradient(white, $neutral-30);
-
-// Brand Gradient
 $brand-gradient: linear-gradient($light-brand-color, $brand-color);
-
-// Accent Gradient
 $accent-gradient: linear-gradient($light-accent-color, $accent-color);
 
 
@@ -110,64 +84,24 @@ $accent-gradient: linear-gradient($light-accent-color, $accent-color);
 // ---
 
 $border-radius: 4px;
+$input-background-color: #fff;
+$input-disabled-color: $neutral-40;
+$input-disabled-background: $neutral-30;
+$focus-color: $accent-color;
 
 
-// Layout
+// Layer (z-index)
 // ---
 
-// We define `$unit` as the basic measure for spacing and alignment of elements.
-// For best results, set a value between 6px and 12px and apply `$unit` in whole
-// and half multiples only. If you’re intentionally breaking from the design
-// system for a certain element, don’t use `$unit`.
-$unit: 10px;
-
-// Deprecated – these will be removed from Vellum in a future release. Feel free
-// to re-define them in your project if you prefer them.
-$h-space: $unit * 2;
-$v-space: $unit;
-
-
-// Form Specific Variables
-// ---
-
-$forms-border-color: $border-color;
-$forms-input-color: #fff;
-$forms-active-border-color: darken($border-color, 10);
-$forms-focus-border-color: $accent-color;
-$forms-border-radius: $border-radius;
-$forms-font-size: $font-size;
-$forms-font-family: $font-family;
-$forms-checked-background: $neutral-30;
-$forms-disabled-color: $disabled-color;
-$forms-disabled-background: $neutral-30;
-$forms-placeholder-color: $neutral-50;
-
-
-// Layers and `z-index`
-// ---
-//
-// Organizes z-index usage by providing a set of named layers. Values can be
-// incremented/decremented slightly as necessary. eg. $stage-layer + 1;
-//
-// 1. “backdrop” should be used for purposefully placing an item behind a staged item. Likely
-//    a background for an element.
-// 2. "stage" should be your first choice for moving an item in front of others. Likely an icon or
-//    an interface element.
-// 3. "orchestra" should be used to explicitly place content in front of the stage.
-//    Likely a modal shield.
-// 4. "frontrow" is your last resort for moving content forward. Likely a
-//    modal dialog.
-
-$backdrop-layer:  1;    // 1
-$stage-layer:     10;   // 2
-$orchestra-layer: 100;  // 3
-$frontrow-layer:  1000; // 4
+$layer-00: 1;    // background
+$layer-10: 10;   // icon or other ui element
+$layer-20: 100;  // modal shade or similar
+$layer-30: 1000; // modal dialog or similar
 
 
 // Shorthand Variables
 // ---
 //
-// This is a place to collect quick ways to write certain properties that you
-// re-use often
+// Quick ways to write properties that you re-use often.
 
 $border: 1px solid $border-color;

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -2,7 +2,7 @@
 // ===
 //
 // - Names should be lowercase and dash-separated;
-// - Related variables should add qualifiers at the beginning: use
+// - Qualifiers should be added to the beginning of related variables: use
 //   `$small-font-size`, not `$font-size-small`;
 // - Numeric scales should use increments of 10; these numbers are arbitrary and
 //   should not map to actual values. If really necessary, additional values can

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -84,10 +84,12 @@ $accent-gradient: linear-gradient($light-accent-color, $accent-color);
 // ---
 
 $border-radius: 4px;
+$focus-color: $accent-color;
+$input-horizontal-padding: $unit;
+$input-vertical-padding: $unit;
 $input-background-color: #fff;
 $input-disabled-color: $neutral-40;
 $input-disabled-background: $neutral-30;
-$focus-color: $accent-color;
 
 
 // Layer (z-index)
@@ -105,3 +107,4 @@ $layer-30: 1000; // modal dialog or similar
 // Quick ways to write properties that you re-use often.
 
 $border: 1px solid $border-color;
+$input-padding: $input-vertical-padding $input-horizontal-padding;

--- a/dist/vellum/_variables.scss
+++ b/dist/vellum/_variables.scss
@@ -12,8 +12,8 @@
 // Layout
 // ---
 
-// Basic unit for spacing and alignment of elements. Suggested value: 6 to 12px.
-// Apply in whole or half multiples.
+// Basic unit for spacing and alignment; 6 to 12px recommended. Apply in whole
+// or half multiples.
 $unit: 10px !default;
 
 // Standard tap-target size
@@ -59,11 +59,6 @@ $error-color: #c0392b; // red
 $light-error-color: lighten($error-color, 15%);
 $dark-error-color: darken($error-color, 15%);
 
-// Text colors
-$font-color: $neutral-70;
-$link-color: $accent-color;
-$active-link-color: $dark-accent-color;
-
 
 // Gradients
 // ---
@@ -79,14 +74,21 @@ $accent-gradient: linear-gradient($light-accent-color, $accent-color);
 // Appearance
 // ---
 
-$input-horizontal-padding: $unit;
-$input-vertical-padding: $unit;
+$font-color: $neutral-70;
+
+$link-color: $accent-color;
+$active-link-color: $dark-accent-color;
+
+$focus-color: $accent-color;
+
 $border-color: $neutral-40;
 $border-radius: 4px;
+
 $input-background-color: #fff;
-$input-disabled-color: $neutral-40;
-$input-disabled-background: $neutral-30;
-$focus-color: $accent-color;
+$disabled-input-color: $neutral-40;
+$disabled-input-background-color: $neutral-30;
+$horizontal-input-padding: $unit;
+$vertical-input-padding: $unit;
 
 
 // Layer (z-index)
@@ -98,10 +100,10 @@ $layer-20: 100;  // modal shade or similar
 $layer-30: 1000; // modal dialog or similar
 
 
-// Shorthand Variables
+// Shorthand
 // ---
 //
 // Quick ways to write properties that you re-use often.
 
 $border: 1px solid $border-color;
-$input-padding: $input-vertical-padding $input-horizontal-padding;
+$input-padding: $vertical-input-padding $horizontal-input-padding;

--- a/test/index.html
+++ b/test/index.html
@@ -253,7 +253,7 @@
                     <input type="submit" value="Submit" />
                     <input type="submit" value="Disabled Submit" disabled/>
                     <button type="button">Button</button>
-                    <button type="button" disabled>Button</button>
+                    <button type="button" disabled>Disabled Button</button>
                 </fieldset>
             </form>
         </section>


### PR DESCRIPTION
Previously #88; re-creating to change target branch as per #89.

For consistency Stencil components will all depend on a [minimal set of shared variables](http://github.com/mobify/stencil-variables). This PR ensures that Vellum plays nice with this set, and removes some unnecessary complexity from the existing variables file. Closes #72.

Status: **Ready to merge**

Reviewers: @tedtate @jeffkamo @fractaltheory 
Ticket: RTM-128/CSOPS-1256
Linked PRs: compare with https://github.com/mobify/stencil-variables/blob/master/variables.scss

## Feedback

- See #88 for discussion.
- [x] +1
- [x] +1

## Changes

Made variable naming guidelines at the top of the file **way** more concise.

Removed or renamed:
- `$sans-serif`: removed; use `$font-family`
- `$serif`: removed
- `$leading-ratio`: removed; use `$line-height` or calculate `($line-height/$font-size)` inline
- `$disabled-color`: removed
- `$background-color`: removed
- `$v-space` and `$-space`: removed, were deprecated; use `$unit` by default
- `$forms-border-color`: removed; use `$border-color` by default
- `$forms-input-color`: renamed → `$input-background-color`
- `$forms-active-border-color`: removed
- `$forms-focus-border-color`: renamed → `$focus-color`
- `$forms-border-radius`: removed; use `$border-radius` by default
- `$forms-font-size`: removed; use `$font-size` by default
- `$forms-font-family`: removed; use `$font-family` by default
- `$forms-checked-background`: removed
- `$forms-disabled-color`: renamed → `$disabled-input-color`
- `$forms-disabled-background`: renamed → `$disabled-input-background-color`
- `$forms-placeholder-color`: removed

Added:
- `$tap-size`: the standard tap-target size; useful for consistent sizing of tappable elements
- `$horizontal-input-padding`, `$vertical-input-padding`: for consistent padding among buttons, inputs and other controls
- `$input-padding`: shorthand value for setting all input padding

## How to test-drive this PR
- Clone the repo and run `npm install && bower install`
- Run the default grunt task (just `grunt` on the command line)
- Open `test/index.html` in a browser
- Check out branch `stencil-sync` and run `grunt again`
- Open a new tab to `text/index.html`
- Ensure things compile; compare the before/after output. Some things will be subtly different, but the after state should be more consistent (e.g. before, some buttons/selects were not consistent heights)