### PR TITLE
Line-height removed from form fields

### DIFF
--- a/dist/base/_forms.scss
+++ b/dist/base/_forms.scss
@@ -51,8 +51,6 @@ textarea,
 
     background-color: $input-background-color;
 
-    line-height: $line-height;
-
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-appearance: none;
 


### PR DESCRIPTION
Status: Ready for review
Reviewers: @ry5n @avelinet @jeffkamo @yourpalsonja @mlworks @cole-sanderson 

Fixes #98.

Changes:
- `line-height` property was removed from fields. It didn't affect anything but Android 4.3 Galaxy 3 where placeholder was not vertically aligned because of the `line-height`.

Tested on Androids:
- 4.1 
- 4.1.2
- 4.3
- 4.4.3
- 5.1.1

Tested on iPhones:
- iPhone 6 iOS8
- iPhone 5S iOS7
- iPhone 4 iOS6 
